### PR TITLE
Fix/init db sleep

### DIFF
--- a/src/stores/manager/eth1/eth1_account.go
+++ b/src/stores/manager/eth1/eth1_account.go
@@ -37,7 +37,7 @@ func NewEth1(ctx context.Context, specs *Specs, eth1Accounts database.ETH1Accoun
 
 		// We sleep to give some time for the token to be set
 		// TODO: this needs to be improved to not rely on time
-		time.Sleep(2 * time.Second)
+		time.Sleep(time.Second)
 	case types.AKVKeys:
 		spec := &akv.KeySpecs{}
 		if err = manifest.UnmarshalSpecs(specs.Specs, spec); err != nil {


### PR DESCRIPTION
There is a concurrency issue between the moment the key store is created and when we initialize it in the eth1 store. This needs to be improved but for the moment we can sleep while so we let time for the token to be renewed.