### PR TITLE
#206 review

### DIFF
--- a/src/auth/policy/service.go
+++ b/src/auth/policy/service.go
@@ -12,6 +12,7 @@ import (
 	manifest "github.com/consensys/quorum-key-manager/src/manifests/types"
 )
 
+//the: avoid globals?
 var authKinds = []manifest.Kind{
 	GroupKind,
 	Kind,
@@ -59,6 +60,7 @@ func (mngr *BaseManager) Stop(context.Context) error {
 	defer mngr.mux.Unlock()
 
 	if mngr.sub != nil {
+		//the: why ignoring the error?
 		_ = mngr.sub.Unsubscribe()
 	}
 	close(mngr.mnfsts)
@@ -101,7 +103,9 @@ func (mngr *BaseManager) UserPolicies(ctx context.Context, info *types.UserInfo)
 	return policies
 }
 
+//the: indicate that this is not thread-safe and we need to lock the mutex before accessing this func, or lock/unlock in here.
 func (mngr *BaseManager) policy(name string) (*types.Policy, error) {
+	//the: https://dave.cheney.net/practical-go/presentations/gophercon-singapore-2019.html#_return_early_rather_than_nesting_deeply
 	if policy, ok := mngr.policies[name]; ok {
 		return policy, nil
 	}
@@ -121,7 +125,9 @@ func (mngr *BaseManager) Policies(context.Context) ([]string, error) {
 	return policies, nil
 }
 
+//the: indicate that this is not thread-safe and we need to lock the mutex before accessing this func, or lock/unlock in here.
 func (mngr *BaseManager) group(name string) (*types.Group, error) {
+	//the: https://dave.cheney.net/practical-go/presentations/gophercon-singapore-2019.html#_return_early_rather_than_nesting_deeply
 	if group, ok := mngr.groups[name]; ok {
 		return group, nil
 	}
@@ -141,15 +147,18 @@ func (mngr *BaseManager) Groups(context.Context) ([]string, error) {
 	return groups, nil
 }
 
+//the: should return an error
 func (mngr *BaseManager) loadAll(ctx context.Context) {
 	for mnfsts := range mngr.mnfsts {
 		for _, mnf := range mnfsts {
+			//the: why ignore the error?
 			_ = mngr.load(ctx, mnf.Manifest)
 		}
 	}
 }
 
 func (mngr *BaseManager) load(_ context.Context, mnf *manifest.Manifest) error {
+	//the: maybe lock in the underlying funcs (loadGroup, loadPolicy)?
 	mngr.mux.Lock()
 	defer mngr.mux.Unlock()
 

--- a/src/auth/policy/service_test.go
+++ b/src/auth/policy/service_test.go
@@ -82,6 +82,7 @@ func TestBaseManager(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Verifies that objects have been properly loaded
+	//the: replace the context.TODO() by a reusable context.Background()
 	group1, err := mngr.Group(context.TODO(), "test-group1")
 	require.NoError(t, err, "Group1 should be stored")
 	assert.Equal(t, "test-group1", group1.Name, "Group1 should have correct name")
@@ -101,6 +102,8 @@ func TestBaseManager(t *testing.T) {
 	require.NoError(t, err, "policy2A should be stored")
 	assert.Equal(t, "test-policy2A", policy2A.Name, "Policy2A should have correct name")
 	assert.Len(t, policy2A.Statements, 1, "Policy2A should have correct statements")
+
+	//the: add a test that adding test-group1 would fail. Same for a policy
 
 	err = manifests.Stop(context.TODO())
 	require.NoError(t, err, "Stop manifests manager must not error")

--- a/src/auth/policy/specs.go
+++ b/src/auth/policy/specs.go
@@ -5,12 +5,14 @@ import (
 	manifest "github.com/consensys/quorum-key-manager/src/manifests/types"
 )
 
+//the: make it const to avoid external abuse
 var GroupKind manifest.Kind = "Group"
 
 type GroupSpecs struct {
 	Policies []string `json:"policies"`
 }
 
+//the: make it const to avoid external abuse
 var Kind manifest.Kind = "Policy"
 
 type Specs struct {

--- a/src/stores/manager/service.go
+++ b/src/stores/manager/service.go
@@ -116,6 +116,7 @@ func (m *BaseManager) Close() error {
 func (m *BaseManager) loadAll(ctx context.Context) {
 	for mnfsts := range m.mnfsts {
 		for _, mnf := range mnfsts {
+			//the: handle the error
 			_ = m.load(ctx, mnf.Manifest)
 		}
 	}


### PR DESCRIPTION
Instead of commenting on the already merged #206 PR, and because I also wanted to comment/ask a little bit out of the diffs, just created a PR with comment was easier.

During my analysis, a go test -race discovered some race condition that should be taken into account, I think.
It is not because of this PR though, so we should maybe just add an issue to fix this.
I would make the CI run the tests with -race, and fix the existing race conditions.

My other comments are mostly about error that are ignored, and I wanted to know why. At some point, the error chain is interrupted by a func not returning an error (BaseManager.loadAll()), and then the calling function returns an error again (BaseManager.Start()), which makes us either create error out of the void with a loss of context, or not do anything at all (the current way), which leaves us to debug and dig into code when that happens.