### PR TITLE
Added soft-deletion checks

### DIFF
--- a/src/stores/connectors/eth1.go
+++ b/src/stores/connectors/eth1.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"context"
+	"github.com/consensys/quorum-key-manager/pkg/errors"
 	"math/big"
 
 	"github.com/consensys/quorum-key-manager/pkg/ethereum"
@@ -161,9 +162,15 @@ func (c Eth1Connector) Undelete(ctx context.Context, addr string) error {
 
 func (c Eth1Connector) Destroy(ctx context.Context, addr string) error {
 	logger := c.logger.With("address", addr)
+	logger.Debug("check ethereum account is soft-deleted")
+
+	_, err := c.GetDeleted(ctx, addr)
+	if err != nil {
+		return errors.StatusConflictError("ethereum account should be deleted before")
+	}
 	logger.Debug("destroying ethereum account")
 
-	err := c.store.Destroy(ctx, addr)
+	err = c.store.Destroy(ctx, addr)
 	if err != nil {
 		return err
 	}

--- a/src/stores/connectors/keys.go
+++ b/src/stores/connectors/keys.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"context"
+	"github.com/consensys/quorum-key-manager/pkg/errors"
 
 	"github.com/consensys/quorum-key-manager/src/auth/policy"
 	"github.com/consensys/quorum-key-manager/src/infra/log"
@@ -146,9 +147,16 @@ func (c KeyConnector) Undelete(ctx context.Context, id string) error {
 
 func (c KeyConnector) Destroy(ctx context.Context, id string) error {
 	logger := c.logger.With("id", id)
+	logger.Debug("check key is soft-deleted")
+
+	_, err := c.GetDeleted(ctx, id)
+	if err != nil {
+		return errors.StatusConflictError("key should be deleted before")
+	}
+
 	logger.Debug("destroying key")
 
-	err := c.store.Destroy(ctx, id)
+	err = c.store.Destroy(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/src/stores/connectors/secrets.go
+++ b/src/stores/connectors/secrets.go
@@ -2,6 +2,7 @@ package connectors
 
 import (
 	"context"
+	"github.com/consensys/quorum-key-manager/pkg/errors"
 
 	"github.com/consensys/quorum-key-manager/src/auth/policy"
 	"github.com/consensys/quorum-key-manager/src/infra/log"
@@ -115,7 +116,16 @@ func (c SecretConnector) Undelete(ctx context.Context, id string) error {
 func (c SecretConnector) Destroy(ctx context.Context, id string) error {
 	logger := c.logger.With("id", id)
 
-	err := c.store.Destroy(ctx, id)
+	logger.Debug("check secret is soft-deleted")
+
+	_, err := c.GetDeleted(ctx, id)
+	if err != nil {
+		return errors.StatusConflictError("secret should be deleted before")
+	}
+
+	logger.Debug("destroying secret")
+
+	err = c.store.Destroy(ctx, id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/consensys/quorum-key-manager/blob/master/CONTRIBUTING.md -->

## PR description

Ensure resource has been soft-deleted prior to destruction ( destroy action )

## Fixed Issue(s)

[#103](https://app.zenhub.com/workspaces/orchestrate-5ea70772b186e10067f57842/issues/consensys/quorum-key-manager/103)

## Changelog

- Deletion state ensured before destroy