### PR TITLE
fix local keys error with using Hashicorp

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,9 +14,9 @@ AUTH_API_KEY_FILE=/apikey/sample.csv
 
 TEST_DATA={"key_manager_url":"https://localhost:8080","health_key_manager_url":"https://localhost:8081","secret_stores":["hashicorp-secrets","akv-secrets","aws-secrets"],"key_stores":["hashicorp-keys"],"eth1_stores":["eth1-accounts"],"quorum_node_id":"quorum-node","besu_node_id":"besu-node"}
 
-## Postgres Configuration
-DB_TLS_SSLMODE=verify-ca
-DB_TLS_CERT=/certificates/client.crt
-DB_TLS_KEY=/certificates/client.key
-DB_TLS_CA=/ca/ca.crt
-DB_HOST=postgres-ssl
+## Postgres SSL
+#DB_TLS_SSLMODE=verify-ca
+#DB_TLS_CERT=/certificates/client.crt
+#DB_TLS_KEY=/certificates/client.key
+#DB_TLS_CA=/ca/ca.crt
+#DB_HOST=postgres-ssl

--- a/src/stores/manager/keys/local.go
+++ b/src/stores/manager/keys/local.go
@@ -55,5 +55,5 @@ func NewLocalKeyStore(specs *LocalKeySpecs, db database.Secrets, logger log.Logg
 		return nil, err
 	}
 
-	return localkeys.New(secretStore, logger), nil
+	return localkeys.New(secretStore, db, logger), nil
 }

--- a/src/stores/store/secrets/hashicorp/hashicorp.go
+++ b/src/stores/store/secrets/hashicorp/hashicorp.go
@@ -227,6 +227,14 @@ func (s *Store) listVersions(ctx context.Context, id string, isDeleted bool) ([]
 		s.logger.WithError(err).Error(errMessage, "id", id)
 		return nil, errors.FromError(err).SetMessage(errMessage)
 	}
+
+	if len(versionList) == 0 {
+		errMsg := "no versions were found for secret"
+		err := errors.NotFoundError("unexpected empty list of secret versions")
+		s.logger.WithError(err).Error(errMsg, "id", id)
+		return nil, errors.FromError(err).SetMessage(errMsg)
+	}
+
 	return versionList, nil
 }
 

--- a/tests/acceptance/acceptance_test.go
+++ b/tests/acceptance/acceptance_test.go
@@ -113,7 +113,7 @@ func (s *storeTestSuite) TestKeyManager_Keys() {
 	testSuite.db = db.Keys(storeName)
 	secretsDB := db.Secrets(storeName)
 	hashicorpSecretStore := hashicorpsecret.New(s.env.hashicorpClient, secretsDB, HashicorpSecretMountPoint, logger)
-	testSuite.store = keys.NewConnector(local.New(hashicorpSecretStore, logger), db.Keys(storeName), auth, logger)
+	testSuite.store = keys.NewConnector(local.New(hashicorpSecretStore, secretsDB, logger), db.Keys(storeName), auth, logger)
 	suite.Run(s.T(), testSuite)
 }
 
@@ -141,7 +141,7 @@ func (s *storeTestSuite) TestKeyManagerStore_Eth1() {
 	logger = s.env.logger.WithComponent(storeName)
 	secretsDB := db.Secrets(storeName)
 	hashicorpSecretStore := hashicorpsecret.New(s.env.hashicorpClient, secretsDB, HashicorpSecretMountPoint, logger)
-	localStore := local.New(hashicorpSecretStore, logger)
+	localStore := local.New(hashicorpSecretStore, secretsDB, logger)
 	testSuite = new(eth1TestSuite)
 	testSuite.env = s.env
 	testSuite.store = eth1.NewConnector(localStore, db.ETH1Accounts(storeName), auth, logger)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/consensys/quorum-key-manager/blob/master/CONTRIBUTING.md -->

## PR description
- Modified LocalKeys to persist secrets in DB so that we can list versions for Restoring and Destroying in Hashicorp

## Fixed Issue(s)
- Fixed error on Restore and Destroy with LocalKeys + Hashicorp 

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://github.com/consensys/quorum-key-manager/blob/master/CHANGELOG.md).