### PR TITLE
disable auth node forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quorum Key Manager Release Notes
 
+## v21.12.2 (Unreleased)
+### 🛠 Bug fixes
+* Invalid authentication forwarded to downstream proxy nodes if QKM authentication is enabled.
+
 ## v21.12.1 (2021-12-20)
 ### 🛠 Bug fixes
 * Fixes a bug in the `sync` command that prevent it from running.

--- a/pkg/http/request/preparer_basic_auth.go
+++ b/pkg/http/request/preparer_basic_auth.go
@@ -16,10 +16,11 @@ func BasicAuth(cfg *BasicAuthConfig) Preparer {
 	}
 
 	return PrepareFunc(func(req *http.Request) (*http.Request, error) {
-		if req.Header.Get("Authorization") != "" {
-			// If Authorization Header is already set then do not alter request
-			return req, nil
-		}
+		// @Important: Disabled Authorization forwarding because QKM credentials are forwarded leading to auth issues in the downstream node
+		// @TODO: Re-enable auth forward once we find out a strategy to spit QKM and Node credentials in the request
+		// if req.Header.Get("Authorization") != "" {
+		// 	return req, nil
+		// }
 
 		u := req.URL.User
 		if u == nil && cfg.Username != "" && cfg.Password != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/consensys/quorum-key-manager/blob/master/CONTRIBUTING.md -->

## PR description
- Invalid authentication forwarded to downstream proxy nodes if QKM authentication is enabled.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://github.com/consensys/quorum-key-manager/blob/master/CHANGELOG.md).