### PR TITLE
add properties to key creation request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quorum Key Manager Release Notes
 
+## v21.12.6 (2023-6-16)
+### 🆕 Features
+* Add AKV HSM support for Keys.
+
 ## v21.12.5 (2022-6-13)
 ### 🛠 Bug fixes
 * Fix panic `d.nx != 0` caused by concurrency issue on hashing credentials.

--- a/src/stores/api/http/keys.go
+++ b/src/stores/api/http/keys.go
@@ -81,7 +81,8 @@ func (h *KeysHandler) create(rw http.ResponseWriter, request *http.Request) {
 			EllipticCurve: entities2.Curve(createKeyRequest.Curve),
 		},
 		&entities.Attributes{
-			Tags: createKeyRequest.Tags,
+			Tags:       createKeyRequest.Tags,
+			Properties: createKeyRequest.Properties,
 		})
 	if err != nil {
 		infrahttp.WriteHTTPErrorResponse(rw, err)

--- a/src/stores/api/types/keys.go
+++ b/src/stores/api/types/keys.go
@@ -10,6 +10,7 @@ type CreateKeyRequest struct {
 	Curve            string            `json:"curve" validate:"required,isCurve" example:"secp256k1" enums:"babyjubjub,secp256k1"`
 	SigningAlgorithm string            `json:"signingAlgorithm" validate:"required,isSigningAlgorithm" example:"ecdsa" enums:"ecdsa,eddsa"`
 	Tags             map[string]string `json:"tags,omitempty"`
+	Properties       map[string]string `json:"properties,omitempty" example:"EC-HSM"`
 }
 
 type ImportKeyRequest struct {

--- a/src/stores/entities/attributes.go
+++ b/src/stores/entities/attributes.go
@@ -29,6 +29,9 @@ type Attributes struct {
 
 	// Tags attached to a stored item
 	Tags map[string]string
+
+	// Properties for further configuration options
+	Properties map[string]string
 }
 
 type Recovery struct {

--- a/src/stores/store/keys/akv/akv.go
+++ b/src/stores/store/keys/akv/akv.go
@@ -3,6 +3,7 @@ package akv
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 	"time"
 
 	entities2 "github.com/consensys/quorum-key-manager/src/entities"
@@ -16,6 +17,10 @@ import (
 	"github.com/consensys/quorum-key-manager/src/infra/akv"
 	"github.com/consensys/quorum-key-manager/src/infra/log"
 	"github.com/consensys/quorum-key-manager/src/stores/entities"
+)
+
+const (
+	AZURE_KEY_VAULT_TYPE = "AZURE_KEY_VAULT_TYPE"
 )
 
 type Store struct {
@@ -45,6 +50,11 @@ func (s *Store) Create(ctx context.Context, id string, alg *entities2.Algorithm,
 	case alg.Type == entities2.Ecdsa && alg.EllipticCurve == entities2.Secp256k1:
 		kty = keyvault.EC
 		crv = keyvault.P256K
+		if keyVaultType, ok := attr.Properties[AZURE_KEY_VAULT_TYPE]; ok {
+			if string(keyvault.ECHSM) == strings.ToUpper(keyVaultType) {
+				kty = keyvault.ECHSM
+			}
+		}
 	default:
 		errMessage := "not supported elliptic curve and signing algorithm in AKV for creation"
 		logger.Error(errMessage)

--- a/src/stores/store/keys/akv/parser.go
+++ b/src/stores/store/keys/akv/parser.go
@@ -42,7 +42,7 @@ func convertToAKVKeyAttr(attr *entities.Attributes) *keyvault.KeyAttributes {
 
 func algoFromAKVKeyTypeCrv(kty keyvault.JSONWebKeyType, crv keyvault.JSONWebKeyCurveName) *entities2.Algorithm {
 	algo := &entities2.Algorithm{}
-	if kty == keyvault.EC {
+	if kty == keyvault.EC || kty == keyvault.ECHSM {
 		algo.Type = entities2.Ecdsa
 	}
 
@@ -55,7 +55,7 @@ func algoFromAKVKeyTypeCrv(kty keyvault.JSONWebKeyType, crv keyvault.JSONWebKeyC
 
 func pubKeyBytes(key *keyvault.JSONWebKey) []byte {
 	switch {
-	case key.Kty == keyvault.EC && key.Crv == keyvault.P256K:
+	case (key.Kty == keyvault.EC || key.Kty == keyvault.ECHSM) && key.Crv == keyvault.P256K:
 		xBytes, _ := decodePubKeyBase64(*key.X)
 		yBytes, _ := decodePubKeyBase64(*key.Y)
 		pKey := ecdsa.PublicKey{X: new(big.Int).SetBytes(xBytes), Y: new(big.Int).SetBytes(yBytes)}


### PR DESCRIPTION
Allow per key type setting for HSM-backed storage in Azure

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/consensys/quorum-key-manager/blob/master/CONTRIBUTING.md -->

## PR description

To support HSM-backed keys in Azure Key Vault, the API payload and service request were extended in a backwards-compatible way to support additional, optional properties. The AKV store supports the `AZURE_KEY_VAULT_TYPE` property with a value of `EC-HSM`. When these are set, the key will be backed by HSM in AKV.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #579

## Changelog
- Added a properties map to the Key Creation API endpoint and service attributes. 
- AKV store supports the `AZURE_KEY_VAULT_TYPE` key and `EC-HSM` value. That will enable HSM-backed keys. 

- [x] I thought about the changelog and included a [changelog update if required](https://github.com/consensys/quorum-key-manager/blob/master/CHANGELOG.md).