### PR TITLE
extend key store spec with optional parameters map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Quorum Key Manager Release Notes
 
+## v21.12.6 (2023-6-18)
+### 🆕 Features
+* Add properties map to AKV Key Store Specs to enable HSM backed keys
+
 ## v21.12.5 (2022-6-13)
 ### 🛠 Bug fixes
 * Fix panic `d.nx != 0` caused by concurrency issue on hashing credentials.

--- a/src/stores/api/manifest/stores.go
+++ b/src/stores/api/manifest/stores.go
@@ -68,7 +68,7 @@ func (h *StoresHandler) CreateKey(ctx context.Context, name string, allowedTenan
 		return errors.InvalidFormatError(err.Error())
 	}
 
-	err = h.stores.CreateKey(ctx, name, createReq.Vault, createReq.SecretStore, allowedTenants, h.userInfo)
+	err = h.stores.CreateKey(ctx, name, createReq.Vault, createReq.SecretStore, allowedTenants, h.userInfo, createReq.Properties)
 	if err != nil {
 		return err
 	}

--- a/src/stores/api/types/stores.go
+++ b/src/stores/api/types/stores.go
@@ -5,8 +5,9 @@ type CreateSecretStoreRequest struct {
 }
 
 type CreateKeyStoreRequest struct {
-	SecretStore string `json:"secretStore,omitempty" yaml:"secret_store,omitempty" example:"my-secret-store"`
-	Vault       string `json:"vault,omitempty" yaml:"vault,omitempty" example:"hashicorp-quorum"`
+	SecretStore string                 `json:"secretStore,omitempty" yaml:"secret_store,omitempty" example:"my-secret-store"`
+	Vault       string                 `json:"vault,omitempty" yaml:"vault,omitempty" example:"hashicorp-quorum"`
+	Properties  map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
 }
 
 type CreateEthereumStoreRequest struct {

--- a/src/stores/connectors/stores/create_key.go
+++ b/src/stores/connectors/stores/create_key.go
@@ -21,9 +21,9 @@ import (
 	"github.com/consensys/quorum-key-manager/pkg/errors"
 )
 
-func (c *Connector) CreateKey(ctx context.Context, name, vaultName, secretStore string, allowedTenants []string, userInfo *authtypes.UserInfo) error {
+func (c *Connector) CreateKey(ctx context.Context, name, vaultName, secretStore string, allowedTenants []string, userInfo *authtypes.UserInfo, properties map[string]interface{}) error {
 	logger := c.logger.With("name", name, "vault", vaultName, "secret_store", secretStore)
-	logger.Debug("creating key store")
+	logger.Debug("creating key store", "properties", properties)
 
 	if vaultName != "" && secretStore != "" {
 		errMessage := "cannot specify vault and secret store simultaneously. Please choose one option"
@@ -48,7 +48,7 @@ func (c *Connector) CreateKey(ctx context.Context, name, vaultName, secretStore 
 		case entities2.HashicorpVaultType:
 			store, err = hashicorp.New(vault.Client.(hashicorpinfra.PluginClient), logger), nil
 		case entities2.AzureVaultType:
-			store, err = akv.New(vault.Client.(akvinfra.KeysClient), logger), nil
+			store, err = akv.New(vault.Client.(akvinfra.KeysClient), logger, properties), nil
 		case entities2.AWSVaultType:
 			store, err = aws.New(vault.Client.(awsinfra.KmsClient), logger), nil
 		default:

--- a/src/stores/stores.go
+++ b/src/stores/stores.go
@@ -14,7 +14,7 @@ type Stores interface {
 	CreateEthereum(_ context.Context, name, keyStore string, allowedTenants []string, userInfo *auth.UserInfo) error
 
 	// CreateKey creates a key store
-	CreateKey(_ context.Context, name, vault, secretStore string, allowedTenants []string, userInfo *auth.UserInfo) error
+	CreateKey(_ context.Context, name, vault, secretStore string, allowedTenants []string, userInfo *auth.UserInfo, properties map[string]interface{}) error
 
 	// CreateSecret creates a secret store
 	CreateSecret(_ context.Context, name, vault string, allowedTenants []string, userInfo *auth.UserInfo) error


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/consensys/quorum-key-manager/blob/master/CONTRIBUTING.md -->

## PR description

PR allows having configuration parameters in the Key Store Specs. AKV Store uses them to set all key using HSM backing.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #579

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://github.com/consensys/quorum-key-manager/blob/master/CHANGELOG.md).